### PR TITLE
Small fixes Add connect4 example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ OUTPUT := .output
 CLANG ?= clang
 LLVM_STRIP ?= llvm-strip
 BPFTOOL ?= bpftool
-LIBBPF_SRC := $(abspath ../libbpf/src)
+LIBBPF_SRC := $(abspath ./libbpf/src)
 LIBBPF_OBJ := $(abspath $(OUTPUT)/libbpf.a)
 
 # Use our own libbpf API headers and Linux UAPI headers distributed with

--- a/bpf/connect.bpf.c
+++ b/bpf/connect.bpf.c
@@ -1,0 +1,17 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include <linux/pkt_cls.h>
+#include <bpf/bpf_helpers.h>
+
+SEC("cgroup/connect4")
+int bpf_sockops_sctp_load(struct bpf_sock_addr *ctx)
+{
+    const char err_str[] = "Hello, world, from BPF! Saw connect() syscall\
+: %x";
+
+    bpf_trace_printk(err_str, sizeof(err_str), ctx->user_ip4);
+
+	return 1;
+}
+
+char _license[] SEC("license") = "GPL";

--- a/topology.sh
+++ b/topology.sh
@@ -10,11 +10,11 @@ up() {
 	ip link add podrouter type dummy
 	ip link set up podrouter
 	ip addr add 192.168.10.1/32 dev podrouter
-	firewall-cmd --direct --add-rule ipv4 nat POSTROUTING 0 -o "$iface" -j MASQUERADE
 	firewall-cmd --permanent --new-zone=playground
 	firewall-cmd --permanent --zone=playground --set-target ACCEPT
 	firewall-cmd --reload
 	firewall-cmd --zone=playground --change-interface podrouter
+	firewall-cmd --direct --add-rule ipv4 nat POSTROUTING 0 -o "$iface" -j MASQUERADE
 
 	create_netns 1 "$iface" 192.168.10.2
 	create_pod 1
@@ -67,7 +67,7 @@ create_netns() {
 create_pod() {
 	pod="pod$1"
 	if [ ! -f .output/config.json ]; then
-		mkdir .output
+		mkdir -p .output
 		skopeo copy docker://alpine:3.16 oci:alpine:3.16
 		umoci unpack --image alpine:3.16 ./.output
 		rm -rf alpine


### PR DESCRIPTION
Libbpf is a submodule so when it's populated it will
be found within the net-ebpf-playground/ subfolder.

Add connect4 example in order to easily demonstrate how
SCTP connect calls are not probed.

Finally on my machine the Masquerade rule was deleted if 
written before the reload. 

Signed-off-by: astoycos <astoycos@redhat.com>