### PR TITLE
Add SK_Lookup + sockops example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,88 @@ sudo tc filter add dev pod1 ingress prio 1 handle 1 bpf object-file .output/filt
 cd socket-redirection
 cargo xtask run
 ```
+
+# Run the SK_LOOKUP Socket Redirection Example
+
+1. Load sockops program and pin map 
+
+```
+    sudo bpftool prog -d load ./.output/sock_ops.bpf.o /sys/fs/bpf/load_sock type sockops
+```
+
+```
+    sudo bpftool map pin name socket_map "/sys/fs/bpf/socket_map"
+```
+
+2. Load sklookup program 
+
+```
+    sudo bpftool prog load ./.output/sk_lookup.bpf.o /sys/fs/bpf/sk_lookup type sk_lookup map name socket_map pinned "/sys/fs/bpf/socket_map"
+```
+
+3. Attach sockops program to default cgroup which will add the server socket to our sockmap
+
+```
+sudo bpftool cgroup attach "/sys/fs/cgroup" sock_ops pinned "/sys/fs/bpf/load_sock"
+```
+
+4. Start server in `pod1`
+
+```
+    sudo ip netns exec pod1 python3 -m http.server
+```
+
+5. Ensure server socket is loaded into map 
+
+
+``` 
+    sudo bpftool map dump name socket_map
+    key:
+    00 00 00 00 00 00 00 00  1f 40 00 00
+    value:
+    No space left on device
+    Found 0 elements
+```
+
+
+6. Attach sklookup prog to `pod1` netns where the python server is running
+
+```
+sudo ./.output/attach-sklookup /sys/fs/bpf/sk_lookup /sys/fs/bpf/sk_lookup_link pod1
+
+```
+
+7. Ensure that the server can be reached from port `8789` (even though it's running 
+    in the pod at port `8000`)
+
+```
+    curl 192.168.10.2:8789
+    <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">
+    <html>
+    ...
+    </html>
+``` 
+
+See sk_lookup program logs 
+
+```
+    sudo cat /sys/kernel/debug/tracing/trace_pipe
+
+    <...>-18104   [007] d.s31 97022.594088: bpf_trace_printk: Saw socket lookup attempt With IP    : 20aa8c0 and port: 2255 
+```
+
+8. Cleanup 
+
+ - Detach skops program 
+
+```
+    sudo bpftool cgroup detach "/sys/fs/cgroup" sock_ops name load_sock
+```
+ - Remove pinned files 
+
+```
+    sudo rm /sys/fs/bpf/load_sock
+    sudo rm /sys/fs/bpf/sk_lookup
+    sudo rm /sys/fs/bpf/sk_lookup_link
+    sudo rm /sys/fs/bpf/socket_map
+```

--- a/bpf/sk_lookup.bpf.c
+++ b/bpf/sk_lookup.bpf.c
@@ -1,0 +1,47 @@
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "sockops_map.bpf.h"
+
+//* Dispatcher program for the echo service */
+SEC("sk_lookup")
+int echo_dispatch(struct bpf_sk_lookup *ctx)
+{
+    const __u32 zero = 0;
+	struct bpf_sock *sk;
+
+    const char err_str[] = "Saw socket lookup attempt With IP: %x and port: %x \n";
+
+    bpf_trace_printk(err_str, sizeof(err_str), ctx->local_ip4, ctx->local_port);
+    
+    // Only deal with lookups to port 8789
+    if (ctx->local_port != 0x2255) { 
+        return SK_PASS;
+    }
+
+    struct socket_key key = { 
+        .src_ip = bpf_htonl(0xc0a80a02), 
+        // Port 8000
+        .src_port = bpf_htons(0x1f40),
+        .dst_ip = 0x00000000,
+        .dst_port = 0x0000,
+    };
+
+    const char err_str4[] = "Failed To lookup Socket: %x and port: %x \n";
+
+    sk = bpf_map_lookup_elem(&socket_map, &key);
+    if (!sk) {
+        bpf_trace_printk(err_str4, sizeof(err_str4), key.src_ip, key.src_port);
+        return SK_PASS;
+    }
+
+    int ret = bpf_sk_assign(ctx, sk, 0);
+    if (ret != 0) {
+        const char err_str3[] = "Failed to assign Socket ret %d \n";
+
+        bpf_trace_printk(err_str3, sizeof(err_str3), ret);
+    }
+
+    bpf_sk_release(sk);
+
+    return SK_PASS;
+}

--- a/bpf/sock_ops.bpf.c
+++ b/bpf/sock_ops.bpf.c
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+#include <bpf/bpf_helpers.h>
+#include "sockops_map.bpf.h"
+
+SEC("sockops")
+int load_sock(struct bpf_sock_ops *skops)
+{       
+    if (skops->local_port == 0x1f40) { 
+        struct socket_key key = {
+            .src_ip = skops->local_ip4,
+            .src_port = bpf_htons(skops->local_port),
+            .dst_ip = skops->remote_ip4,
+            .dst_port = skops->remote_port,
+        };
+
+        // insert the source socket in the sock_ops_map
+        int ret = bpf_sock_hash_update(skops, &socket_map, &key, BPF_NOEXIST);
+        if (ret != 0) {
+            const char err_str[] = "Failed to Load Socket\
+            for VIP: %x with port: %x \n";
+
+            bpf_trace_printk(err_str, sizeof(err_str), skops->local_ip4, skops->local_port);
+        }
+    }
+
+	return 0;
+}

--- a/bpf/sockops_map.bpf.h
+++ b/bpf/sockops_map.bpf.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#include <linux/bpf.h>
+
+char _license[] SEC("license") = "GPL";
+
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#define bpf_htons(x) __builtin_bswap16(x)
+#define bpf_htonl(x) __builtin_bswap32(x)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#define bpf_htons(x) (x)
+#define bpf_htonl(x) (x)
+#else
+#error "__BYTE_ORDER__ error"
+#endif
+
+struct socket_key {
+  __u32 src_ip;
+  __u32 dst_ip;
+  __u16 src_port;
+  __u16 dst_port;
+};
+
+// Explicitly only add src and dst Port
+struct {
+  __uint(type, BPF_MAP_TYPE_SOCKHASH); 
+  __type(key, struct socket_key);
+  __type(value, __u32); 
+  __uint(max_entries, 1);
+} socket_map SEC(".maps");

--- a/userspace/attach-sklookup.c
+++ b/userspace/attach-sklookup.c
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+/* Copyright (c) 2020 Cloudflare */
+
+#include <errno.h>
+#include <error.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <linux/bpf.h>
+
+#include "syscall.h"
+
+int bpf(enum bpf_cmd cmd, union bpf_attr *attr, unsigned int size)
+{
+    return syscall(__NR_bpf, cmd, attr, size);
+}
+
+int main(int argc, char **argv)
+{
+	const char *prog_path;
+	const char *link_path;
+	const char *netns;
+	union bpf_attr attr;
+	int prog_fd, netns_fd, link_fd, err;
+	char netns_path[50]; 
+
+	if (argc != 4) {
+		fprintf(stderr, "Usage: %s <prog path> <link path> <netns name>\n", argv[0]);
+		exit(EXIT_SUCCESS);
+	}
+
+	prog_path = argv[1];
+	link_path = argv[2];
+	netns = argv[3];
+
+	/* 1. Open the pinned BPF program */
+	memset(&attr, 0, sizeof(attr));
+	attr.pathname = (uint64_t) prog_path;
+	attr.file_flags = BPF_F_RDONLY;
+
+	prog_fd = bpf(BPF_OBJ_GET, &attr, sizeof(attr));
+	if (prog_fd == -1)
+		error(EXIT_FAILURE, errno, "bpf(OBJ_GET)");
+
+	/* 2. Get an FD for this process network namespace (netns) */
+	sprintf(netns_path, "/var/run/netns/%s", netns); 
+	
+	netns_fd = open(netns_path, O_RDONLY | O_CLOEXEC);
+	if (netns_fd == -1)
+		error(EXIT_FAILURE, errno, "open");
+
+	/* 3. Attach BPF sk_lookup program to the (netns) with a BPF link */
+	memset(&attr, 0, sizeof(attr));
+	attr.link_create.prog_fd = prog_fd;
+	attr.link_create.target_fd = netns_fd;
+	attr.link_create.attach_type = BPF_SK_LOOKUP;
+	attr.link_create.flags = 0;
+
+	link_fd = bpf(BPF_LINK_CREATE, &attr, sizeof(attr));
+	if (link_fd == -1)
+		error(EXIT_FAILURE, errno, "bpf(LINK_CREATE)");
+
+	/* 4. Pin the BPF link (otherwise would be destroyed on FD close) */
+	memset(&attr, 0, sizeof(attr));
+	attr.pathname = (uint64_t) link_path;
+	attr.bpf_fd = link_fd;
+	attr.file_flags = 0;
+
+	err = bpf(BPF_OBJ_PIN, &attr, sizeof(attr));
+	if (err)
+		error(EXIT_FAILURE, errno, "bpf(OBJ_PIN)");
+
+	close(link_fd);
+	close(netns_fd);
+	close(prog_fd);
+
+	exit(EXIT_SUCCESS);
+}

--- a/userspace/attach-sklookup.c
+++ b/userspace/attach-sklookup.c
@@ -47,7 +47,13 @@ int main(int argc, char **argv)
 		error(EXIT_FAILURE, errno, "bpf(OBJ_GET)");
 
 	/* 2. Get an FD for this process network namespace (netns) */
-	sprintf(netns_path, "/var/run/netns/%s", netns); 
+	if(strcmp(netns,"self") != 0) {
+		sprintf(netns_path, "/var/run/netns/%s", netns);
+	} else {
+		sprintf(netns_path, "/proc/self/ns/net");
+	}
+
+	printf("Attaching to network namespace: %s\n", netns_path);
 	
 	netns_fd = open(netns_path, O_RDONLY | O_CLOEXEC);
 	if (netns_fd == -1)


### PR DESCRIPTION
Add Basic sockops example to proxy
port 8789 on a container to a server running
at port 8000.

Add ability to build userspace programs

Add a make target for compiling c programs.
Ouput to same place as bytecode.

Stop stripping BTF so bpf can run successfully on fedora with bpftool 

